### PR TITLE
add curl style request debug info for the sake of easier reproduced by hand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tests/tests
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tests/tests
 .idea/
+vendor/*/

--- a/common/client.go
+++ b/common/client.go
@@ -3,6 +3,8 @@ package common
 import (
 	"log"
 	"net/http"
+
+	"github.com/moul/http2curl"
 )
 
 type Client struct {
@@ -35,6 +37,10 @@ func (c *Client) Send(request Request, response Response) (err error) {
 		httpRequest.Header["Content-Type"] = []string{"application/x-www-form-urlencoded"}
 	}
 	log.Printf("[DEBUG] http request=%v", httpRequest)
+
+	command, _ := http2curl.GetCurlCommand(httpRequest)
+	log.Printf("[DEBUG] %v", command)
+
 	httpResponse, err := c.httpClient.Do(httpRequest)
 	log.Printf("[DEBUG] http response=%v", httpResponse)
 	err = ParseFromHttpResponse(httpResponse, response)

--- a/common/response.go
+++ b/common/response.go
@@ -45,7 +45,7 @@ func (r *BaseResponse) ParseErrorFromHTTPResponse(body []byte) (err error) {
 	if err != nil {
 		return
 	}
-	log.Printf("[DEBUG] try deprecated error=%s", deprecated)
+	log.Printf("[DEBUG] try deprecated error=%v", deprecated)
 	if deprecated.Code != 0 {
 		return NewAPIError(deprecated.CodeDesc, deprecated.Message, deprecated.Code)
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,0 +1,13 @@
+{
+	"comment": "",
+	"ignore": "test",
+	"package": [
+		{
+			"checksumSHA1": "CxNwJP++vjUAyy3bbJnNss1Il9Q=",
+			"path": "github.com/moul/http2curl",
+			"revision": "9ac6cf4d929b2fa8fd2d2e6dec5bb0feb4f4911d",
+			"revisionTime": "2017-09-19T18:10:01Z"
+		}
+	],
+	"rootPath": "github.com/zqfan/tencentcloud-sdk-go"
+}


### PR DESCRIPTION
the benefit is obvious, we can copy paste the info and run it again.